### PR TITLE
[BE-09] - Custome Error

### DIFF
--- a/app/newsletters/delivery/http/newsletter.go
+++ b/app/newsletters/delivery/http/newsletter.go
@@ -32,7 +32,7 @@ func (h handler) Subscribe(w http.ResponseWriter, r *http.Request) {
 
 	err = h.usecase.Subscribe(r.Context(), payload.Email)
 	if err != nil {
-		resp := utils.CostumErr(err.Error())
+		resp := utils.CustomErrorResponse(err)
 		utils.Response(resp, w)
 		return
 	}

--- a/app/users/delivery/http/login_users.go
+++ b/app/users/delivery/http/login_users.go
@@ -23,25 +23,21 @@ import (
 func (h Handler) Login(w http.ResponseWriter, r *http.Request) {
 	bodyBytes, err := io.ReadAll(r.Body)
 	if err != nil {
-		utils.Response(domain.HttpResponse{
-			Code:    500,
-			Message: err.Error(),
-		}, w)
+		resp := utils.CustomErrorResponse(err)
+		utils.Response(resp, w)
 		return
 	}
 
 	loginInstance := domain.Login{}
 	if err := json.Unmarshal(bodyBytes, &loginInstance); err != nil {
-		utils.Response(domain.HttpResponse{
-			Code:    500,
-			Message: err.Error(),
-		}, w)
+		resp := utils.CustomErrorResponse(err)
+		utils.Response(resp, w)
 		return
 	}
 
 	_, token, err := h.usecase.Login(r.Context(), loginInstance)
 	if err != nil {
-		resp := utils.CostumErr(err.Error())
+		resp := utils.CustomErrorResponse(err)
 		utils.Response(resp, w)
 		return
 	}

--- a/app/users/delivery/http/logout_users.go
+++ b/app/users/delivery/http/logout_users.go
@@ -22,7 +22,7 @@ func (h Handler) Logout(w http.ResponseWriter, r *http.Request) {
 
 	err := h.usecase.Logout(r.Context(), *token)
 	if err != nil {
-		resp := utils.CostumErr(err.Error())
+		resp := utils.CustomErrorResponse(err)
 		utils.Response(resp, w)
 		return
 	}

--- a/app/users/delivery/http/register_users.go
+++ b/app/users/delivery/http/register_users.go
@@ -38,7 +38,7 @@ func (h Handler) Register(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if user.Password != user.ConfirmPassword {
-		err := utils.NewBadRequestError("Confirm password doesn't match", nil)
+		err := utils.NewBadRequestError(r.Context(), "Confirm password doesn't match", nil)
 		resp := utils.CustomErrorResponse(err)
 		utils.Response(resp, w)
 		return

--- a/app/users/delivery/http/register_users.go
+++ b/app/users/delivery/http/register_users.go
@@ -25,28 +25,22 @@ import (
 func (h Handler) Register(w http.ResponseWriter, r *http.Request) {
 	bodyBytes, err := io.ReadAll(r.Body)
 	if err != nil {
-		utils.Response(domain.HttpResponse{
-			Code:    500,
-			Message: err.Error(),
-		}, w)
+		resp := utils.CustomErrorResponse(err)
+		utils.Response(resp, w)
 		return
 	}
 
 	user := domain.Register{}
 	if err = json.Unmarshal(bodyBytes, &user); err != nil {
-		utils.Response(domain.HttpResponse{
-			Code:    500,
-			Message: err.Error(),
-		}, w)
+		resp := utils.CustomErrorResponse(err)
+		utils.Response(resp, w)
 		return
 	}
 
 	if user.Password != user.ConfirmPassword {
-		utils.Response(domain.HttpResponse{
-			Code:    400,
-			Message: "Confirm password doesnt match",
-			Data:    nil,
-		}, w)
+		err := utils.NewBadRequestError("Confirm password doesn't match", nil)
+		resp := utils.CustomErrorResponse(err)
+		utils.Response(resp, w)
 		return
 	}
 
@@ -54,7 +48,7 @@ func (h Handler) Register(w http.ResponseWriter, r *http.Request) {
 	_, err = h.usecase.Register(r.Context(), userInput)
 	if err != nil {
 		logrus.Error("userUsecase: failed to register user")
-		resp := utils.CostumErr(err.Error())
+		resp := utils.CustomErrorResponse(err)
 		utils.Response(resp, w)
 		return
 	}

--- a/app/users/usecase/login_users.go
+++ b/app/users/usecase/login_users.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/hammer-code/lms-be/domain"
 	"github.com/hammer-code/lms-be/utils"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -13,14 +12,12 @@ func (us *usecase) Login(ctx context.Context, userReq domain.Login) (user domain
 	err = us.dbTX.StartTransaction(ctx, func(txCtx context.Context) error {
 		user, err = us.userRepo.FindByEmail(ctx, userReq.Email)
 		if err != nil {
-			logrus.Error("us.LoginUser: failed to find user by email", err)
-			err = utils.NewInternalServerError(err)
+			err = utils.NewInternalServerError(ctx, err)
 			return err
 		}
 	
 		if err = bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(userReq.Password)); err != nil {
-			logrus.Error("us.Login: invalid password")
-			err = utils.NewBadRequestError("Email or Password is invalid", err)
+			err = utils.NewBadRequestError(ctx, "Email or Password is invalid", err)
 			return err
 		}
 	
@@ -29,19 +26,16 @@ func (us *usecase) Login(ctx context.Context, userReq domain.Login) (user domain
 		token = *tokenPtr
 		
 		if err != nil {
-			logrus.Error("us.Login: failed to generate token", err)
-			err = utils.NewInternalServerError(err)
+			err = utils.NewInternalServerError(ctx, err)
 			return err
 		}
 
 		if err = us.userRepo.UnactivateTokenByUser(ctx, user.ID); err != nil {
-			logrus.Error("us.Login: failed to unactivate token", err)
-			err = utils.NewInternalServerError(err)
+			err = utils.NewInternalServerError(ctx, err)
 			return err
 		}
 		if err = us.userRepo.StoreToken(ctx, token, expiredTime, user.ID); err != nil {
-			logrus.Error("us.Login: failed to store token", err)
-			err = utils.NewInternalServerError(err)
+			err = utils.NewInternalServerError(ctx, err)
 			return err
 		}
 
@@ -49,8 +43,7 @@ func (us *usecase) Login(ctx context.Context, userReq domain.Login) (user domain
 	})
 
 	if err != nil {
-		logrus.Error("us.Login: failed to login", err)
-		err = utils.NewInternalServerError(err)
+		err = utils.NewInternalServerError(ctx, err)
 		return
 	}
 

--- a/app/users/usecase/login_users.go
+++ b/app/users/usecase/login_users.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/hammer-code/lms-be/domain"
+	"github.com/hammer-code/lms-be/utils"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -12,12 +13,14 @@ func (us *usecase) Login(ctx context.Context, userReq domain.Login) (user domain
 	err = us.dbTX.StartTransaction(ctx, func(txCtx context.Context) error {
 		user, err = us.userRepo.FindByEmail(ctx, userReq.Email)
 		if err != nil {
-			logrus.Error("us.LoginUser: failed to login", err)
+			logrus.Error("us.LoginUser: failed to find user by email", err)
+			err = utils.NewInternalServerError(err)
 			return err
 		}
 	
 		if err = bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(userReq.Password)); err != nil {
 			logrus.Error("us.Login: invalid password")
+			err = utils.NewBadRequestError("Email or Password is invalid", err)
 			return err
 		}
 	
@@ -26,16 +29,19 @@ func (us *usecase) Login(ctx context.Context, userReq domain.Login) (user domain
 		token = *tokenPtr
 		
 		if err != nil {
-			logrus.Error("us.Login: failed to login. ", err)
+			logrus.Error("us.Login: failed to generate token", err)
+			err = utils.NewInternalServerError(err)
 			return err
 		}
 
 		if err = us.userRepo.UnactivateTokenByUser(ctx, user.ID); err != nil {
-			logrus.Error("us.Login: failed to login. ", err)
+			logrus.Error("us.Login: failed to unactivate token", err)
+			err = utils.NewInternalServerError(err)
 			return err
 		}
 		if err = us.userRepo.StoreToken(ctx, token, expiredTime, user.ID); err != nil {
-			logrus.Error("us.Login: failed to login. ", err)
+			logrus.Error("us.Login: failed to store token", err)
+			err = utils.NewInternalServerError(err)
 			return err
 		}
 
@@ -43,7 +49,8 @@ func (us *usecase) Login(ctx context.Context, userReq domain.Login) (user domain
 	})
 
 	if err != nil {
-		logrus.Error("us.Login: failed to login. ", err)
+		logrus.Error("us.Login: failed to login", err)
+		err = utils.NewInternalServerError(err)
 		return
 	}
 

--- a/app/users/usecase/logout_users.go
+++ b/app/users/usecase/logout_users.go
@@ -4,21 +4,18 @@ import (
 	"context"
 
 	"github.com/hammer-code/lms-be/utils"
-	"github.com/sirupsen/logrus"
 )
 
 func (us *usecase) Logout(ctx context.Context, token string) error {
 	jwtData, err := us.jwt.VerifyToken(token)
 	if err != nil {
-		logrus.Error("us.LogoutUser: failed to varify token", err)
-		err = utils.NewInternalServerError(err)
+		err = utils.NewInternalServerError(ctx, err)
 		return err
 	}
 
 	err = us.userRepo.LogoutUser(ctx, token, jwtData.ExpiresAt.Time)
 	if err != nil {
-		logrus.Error("us.LogoutUser: failed to logout", err)
-		err = utils.NewInternalServerError(err)
+		err = utils.NewInternalServerError(ctx, err)
 		return err
 	}
 	return err

--- a/app/users/usecase/logout_users.go
+++ b/app/users/usecase/logout_users.go
@@ -1,12 +1,25 @@
 package usecase
 
-import "context"
+import (
+	"context"
+
+	"github.com/hammer-code/lms-be/utils"
+	"github.com/sirupsen/logrus"
+)
 
 func (us *usecase) Logout(ctx context.Context, token string) error {
 	jwtData, err := us.jwt.VerifyToken(token)
 	if err != nil {
+		logrus.Error("us.LogoutUser: failed to varify token", err)
+		err = utils.NewInternalServerError(err)
 		return err
 	}
 
-	return us.userRepo.LogoutUser(ctx, token, jwtData.ExpiresAt.Time)
+	err = us.userRepo.LogoutUser(ctx, token, jwtData.ExpiresAt.Time)
+	if err != nil {
+		logrus.Error("us.LogoutUser: failed to logout", err)
+		err = utils.NewInternalServerError(err)
+		return err
+	}
+	return err
 }

--- a/app/users/usecase/register_users.go
+++ b/app/users/usecase/register_users.go
@@ -5,16 +5,18 @@ import (
 
 	"github.com/hammer-code/lms-be/constants"
 	"github.com/hammer-code/lms-be/domain"
+	"github.com/hammer-code/lms-be/utils"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/bcrypt"
 )
 
 func (us *usecase) Register(ctx context.Context, userReq domain.User) (domain.User, error) {
 	user := domain.User{}
-	if err := us.dbTX.StartTransaction(ctx, func(txCtx context.Context) error {
+	err := us.dbTX.StartTransaction(ctx, func(txCtx context.Context) error {
 		hashPassword, err := bcrypt.GenerateFromPassword([]byte(userReq.Password), bcrypt.DefaultCost)
 		if err != nil {
-			logrus.Error("us.Register: failed to register user", err)
+			logrus.Error("us.Register: failed to hash password", err)
+			err = utils.NewInternalServerError(err)
 			return err
 		}
 
@@ -23,14 +25,18 @@ func (us *usecase) Register(ctx context.Context, userReq domain.User) (domain.Us
 		user, err = us.userRepo.CreateUser(ctx, userReq)
 		if err != nil {
 			logrus.Error("us.Register: failed to register users. ", err)
-
+			err = utils.NewInternalServerError(err)
 			return err
 		}
 		return nil
 
-	}); err != nil {
-		logrus.Error("us.Register: failed to get users. ", err)
+	})
+
+	if err != nil {
+		logrus.Error("us.Register: failed to register users. ", err)
+		err = utils.NewInternalServerError(err)
 		return domain.User{}, err
 	}
+	
 	return user, nil
 }

--- a/app/users/usecase/register_users.go
+++ b/app/users/usecase/register_users.go
@@ -6,7 +6,6 @@ import (
 	"github.com/hammer-code/lms-be/constants"
 	"github.com/hammer-code/lms-be/domain"
 	"github.com/hammer-code/lms-be/utils"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -15,8 +14,7 @@ func (us *usecase) Register(ctx context.Context, userReq domain.User) (domain.Us
 	err := us.dbTX.StartTransaction(ctx, func(txCtx context.Context) error {
 		hashPassword, err := bcrypt.GenerateFromPassword([]byte(userReq.Password), bcrypt.DefaultCost)
 		if err != nil {
-			logrus.Error("us.Register: failed to hash password", err)
-			err = utils.NewInternalServerError(err)
+			err = utils.NewInternalServerError(ctx, err)
 			return err
 		}
 
@@ -24,8 +22,7 @@ func (us *usecase) Register(ctx context.Context, userReq domain.User) (domain.Us
 		userReq.Role = constants.RoleUser
 		user, err = us.userRepo.CreateUser(ctx, userReq)
 		if err != nil {
-			logrus.Error("us.Register: failed to register users. ", err)
-			err = utils.NewInternalServerError(err)
+			err = utils.NewInternalServerError(ctx, err)
 			return err
 		}
 		return nil
@@ -33,8 +30,7 @@ func (us *usecase) Register(ctx context.Context, userReq domain.User) (domain.Us
 	})
 
 	if err != nil {
-		logrus.Error("us.Register: failed to register users. ", err)
-		err = utils.NewInternalServerError(err)
+		err = utils.NewInternalServerError(ctx, err)
 		return domain.User{}, err
 	}
 	

--- a/utils/costum_error.go
+++ b/utils/costum_error.go
@@ -1,11 +1,13 @@
 package utils
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/hammer-code/lms-be/domain"
+	"github.com/hammer-code/lms-be/pkg/ngelog"
 )
 
 const (
@@ -27,7 +29,8 @@ func (e *CustomHttpError) Error() string {
 	return e.Message
 }
 
-func NewBadRequestError(msg string, err error) *CustomHttpError {
+func NewBadRequestError(ctx context.Context, msg string, err error) *CustomHttpError {
+	ngelog.Error(ctx, msg, err)
 	return &CustomHttpError{
 		Code:    http.StatusBadRequest,
 		Message: msg,
@@ -35,7 +38,8 @@ func NewBadRequestError(msg string, err error) *CustomHttpError {
 	}
 }
 
-func NewUnauthorizedError(msg string, err error) *CustomHttpError {
+func NewUnauthorizedError(ctx context.Context, msg string, err error) *CustomHttpError {
+	ngelog.Error(ctx, msg, err)
 	return &CustomHttpError{
 		Code:    http.StatusUnauthorized,
 		Message: msg,
@@ -43,7 +47,8 @@ func NewUnauthorizedError(msg string, err error) *CustomHttpError {
 	}
 }
 
-func NewInternalServerError(err error) *CustomHttpError {
+func NewInternalServerError(ctx context.Context, err error) *CustomHttpError {
+	ngelog.Error(ctx, "Internal server error", err)
 	return &CustomHttpError{
 		Code:    http.StatusInternalServerError,
 		Message: "Internal server error",
@@ -62,18 +67,17 @@ func CheckError(errStr, containsStr, message string, code int) (domain.HttpRespo
 }
 
 func CustomErrorResponse(err error) domain.HttpResponse {
-	fmt.Println("YOW", err)
 	if customErr, ok := err.(*CustomHttpError); ok {
 		var errStr string
 		if customErr.OriginError != nil {
 			errStr = customErr.OriginError.Error()
 		}
-		resp, ok := CheckError(errStr, ErrDuplicateEmail, "User already exist", 400)
+		resp, ok := CheckError(errStr, ErrDuplicateEmail, "User already exist", http.StatusBadRequest)
 		if ok {
 			return resp
 		}
 
-		resp, ok = CheckError(errStr, ErrWrongPassword, "Sorry, your password is incorrect", 400)
+		resp, ok = CheckError(errStr, ErrWrongPassword, "Sorry, your password is incorrect", http.StatusBadRequest)
 		if ok {
 			return resp
 		}

--- a/utils/costum_error.go
+++ b/utils/costum_error.go
@@ -1,13 +1,47 @@
 package utils
 
 import (
+	"net/http"
 	"strings"
 
 	"github.com/hammer-code/lms-be/domain"
 )
 
-func CheckError(err, sub, message string, code int) (domain.HttpResponse, bool) {
+type CustomHttpError struct {
+	Code int
+	Message string
+	OriginError error
+}
 
+func (e *CustomHttpError) Error() string {
+	return e.Message
+}
+
+func NewBadRequestError(msg string, err error) *CustomHttpError {
+	return &CustomHttpError{
+		Code:    http.StatusBadRequest,
+		Message: msg,
+		OriginError: err,
+	}
+}
+
+func NewUnauthorizedError(msg string, err error) *CustomHttpError {
+	return &CustomHttpError{
+		Code:    http.StatusUnauthorized,
+		Message: msg,
+		OriginError: err,
+	}
+}
+
+func NewInternalServerError(err error) *CustomHttpError {
+	return &CustomHttpError{
+		Code:    http.StatusInternalServerError,
+		Message: "Internal server error",
+		OriginError: err,
+	}
+}
+
+func CheckError(err, sub, message string, code int) (domain.HttpResponse, bool) {
 	if strings.Contains(err, sub) {
 		return domain.HttpResponse{
 			Code:    code,
@@ -17,25 +51,32 @@ func CheckError(err, sub, message string, code int) (domain.HttpResponse, bool) 
 	return domain.HttpResponse{}, false
 }
 
-func CostumErr(err string) domain.HttpResponse {
+func CustomErrorResponse(err error) domain.HttpResponse {
+	if customErr, ok := err.(*CustomHttpError); ok {
+		errStr := customErr.OriginError.Error()
+		resp, ok := CheckError(errStr, "\"uni_users_email\" (SQLSTATE 23505)", "User already exist", 400)
+		if ok {
+			return resp
+		}
 
-	resp, ok := CheckError(err, "\"uni_users_email\" (SQLSTATE 23505)", "User already exist", 400)
-	if ok {
-		return resp
-	}
+		resp, ok = CheckError(errStr, "\"uni_logout_token\" (SQLSTATE 23505)", "You have already logged out.", 400)
+		if ok {
+			return resp
+		}
 
-	resp, ok = CheckError(err, "\"uni_logout_token\" (SQLSTATE 23505)", "You have already logged out.", 400)
-	if ok {
-		return resp
-	}
+		resp, ok = CheckError(errStr, "password", "Sorry, your password is incorrect", 400)
+		if ok {
+			return resp
+		}
 
-	resp, ok = CheckError(err, "password", "Sorry, your password is incorrect", 400)
-	if ok {
-		return resp
+		return domain.HttpResponse{
+			Code:    customErr.Code,
+			Message: customErr.Message,
+		}
 	}
 
 	return domain.HttpResponse{
-		Code:    400,
+		Code:    http.StatusInternalServerError,
 		Message: "Internal server error",
 	}
 

--- a/utils/costum_error.go
+++ b/utils/costum_error.go
@@ -1,10 +1,17 @@
 package utils
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/hammer-code/lms-be/domain"
+)
+
+const (
+	ErrDuplicateEmail 	 = "\"uni_users_email\" (SQLSTATE 23505)"
+	ErrWrongPassword  	 = "password"
+	ErrNotFoundSQL       = "sql: no rows in result set"
 )
 
 type CustomHttpError struct {
@@ -14,6 +21,9 @@ type CustomHttpError struct {
 }
 
 func (e *CustomHttpError) Error() string {
+	if e.OriginError != nil {
+		return fmt.Sprintf("%s: %s", e.Message, e.OriginError.Error())
+	}
 	return e.Message
 }
 
@@ -41,8 +51,8 @@ func NewInternalServerError(err error) *CustomHttpError {
 	}
 }
 
-func CheckError(err, sub, message string, code int) (domain.HttpResponse, bool) {
-	if strings.Contains(err, sub) {
+func CheckError(errStr, containsStr, message string, code int) (domain.HttpResponse, bool) {
+	if strings.Contains(errStr, containsStr) {
 		return domain.HttpResponse{
 			Code:    code,
 			Message: message,
@@ -52,19 +62,23 @@ func CheckError(err, sub, message string, code int) (domain.HttpResponse, bool) 
 }
 
 func CustomErrorResponse(err error) domain.HttpResponse {
+	fmt.Println("YOW", err)
 	if customErr, ok := err.(*CustomHttpError); ok {
-		errStr := customErr.OriginError.Error()
-		resp, ok := CheckError(errStr, "\"uni_users_email\" (SQLSTATE 23505)", "User already exist", 400)
+		var errStr string
+		if customErr.OriginError != nil {
+			errStr = customErr.OriginError.Error()
+		}
+		resp, ok := CheckError(errStr, ErrDuplicateEmail, "User already exist", 400)
 		if ok {
 			return resp
 		}
 
-		resp, ok = CheckError(errStr, "\"uni_logout_token\" (SQLSTATE 23505)", "You have already logged out.", 400)
+		resp, ok = CheckError(errStr, ErrWrongPassword, "Sorry, your password is incorrect", 400)
 		if ok {
 			return resp
 		}
 
-		resp, ok = CheckError(errStr, "password", "Sorry, your password is incorrect", 400)
+		resp, ok = CheckError(errStr, ErrNotFoundSQL, "Data not found", http.StatusNotFound)
 		if ok {
 			return resp
 		}


### PR DESCRIPTION
Create update custom error functionality

Usage 
- create new custom error
  example :
  ```go
  err := utils.NewBadRequestError("Custom Error Message", originalError)
  // for Internal Server Error just receive original error
  err := utils.NewInternalServerError(originalError)
  ```
- on handler or delivery layer use CustomErrorResponse function to make a default response body for error
  ```go
  resp := utils.CustomErrorResponse(err)
  // write to response body
  utils.Response(resp, w)
  ```